### PR TITLE
Make pdf filler throw errors if fields don't match

### DIFF
--- a/src/pdfFiller/fillPdf.ts
+++ b/src/pdfFiller/fillPdf.ts
@@ -10,24 +10,20 @@ import { displayRound } from '../irsForms/util'
 export function fillPDF(pdf: PDFDocument, fieldValues: Field[]): void {
   const formFields = pdf.getForm().getFields()
 
-  let stop = false
-
   formFields.forEach((pdfField, index) => {
     const value: Field = fieldValues[index]
 
-    if (stop) {
-      return
-    } else if (pdfField instanceof PDFCheckBox) {
+    const error = (expected: string): Error => {
+      return new Error(
+        `Field ${index}, ${pdfField.getName()} expected ${expected}`
+      )
+    }
+
+    if (pdfField instanceof PDFCheckBox) {
       if (value === true) {
         pdfField.check()
       } else if (value !== false && value !== undefined) {
-        console.error(
-          `Expected boolean value in fields, index:${index}, found ${
-            value ?? 'undefined'
-          }`
-        )
-        console.error(pdfField.getName())
-        stop = true
+        throw error('boolean')
       }
     } else if (pdfField instanceof PDFTextField) {
       try {
@@ -35,11 +31,8 @@ export function fillPDF(pdf: PDFDocument, fieldValues: Field[]): void {
           ? displayRound(value as number | undefined)?.toString()
           : value?.toString()
         pdfField.setText(showValue)
-      } catch (error) {
-        console.error(`Error at index ${index}`)
-        console.error(`Field: ${pdfField.getName()}`)
-        console.error(error)
-        stop = true
+      } catch (err) {
+        throw error('text field')
       }
     }
     pdfField.enableReadOnly()

--- a/src/tests/pdfFiller/fillPdf.test.ts
+++ b/src/tests/pdfFiller/fillPdf.test.ts
@@ -41,7 +41,13 @@ describe('fillPdf', () => {
   it('should stop filling when non-boolean is passed to field type Checkbox', async () => {
     const pdf = await localPDFs('irs/f1040.pdf')
     const fieldsValue = ['Test', false, true, true, true, 'One', 'Two']
-    fillPDF(pdf, fieldsValue)
+    try {
+      fillPDF(pdf, fieldsValue)
+      expect('this line').not.toBe('reached')
+    } catch (e) {
+      const err = e as Error
+      expect(err.message).toContain('boolean')
+    }
 
     const fields = pdf.getForm().getFields()
     expectCheckbox(fields[0]).toBe(false)


### PR DESCRIPTION
Without this, errors will be printed to console and missed in test. We want 100% parity between our models and pdf fields.

**What kind of change does this PR introduce?** (delete not applicable)
- Bugfix

